### PR TITLE
FEAT : 이메일 인증 전 데이터 처리 구분

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ build/
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
-src/main/resources/application.yml
 
 ### IntelliJ IDEA ###
 .idea
@@ -26,6 +25,7 @@ src/main/resources/application.yml
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+src/main/resources/application.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/com/justyou/justme/JustmeApplication.java
+++ b/src/main/java/com/justyou/justme/JustmeApplication.java
@@ -4,13 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableJpaRepositories
+@EnableRedisRepositories
 public class JustmeApplication {
     public static void main(String[] args) {
         SpringApplication.run(JustmeApplication.class, args);
     }
-
 }

--- a/src/main/java/com/justyou/justme/component/MailComponent.java
+++ b/src/main/java/com/justyou/justme/component/MailComponent.java
@@ -1,7 +1,8 @@
 package com.justyou.justme.component;
 
 import com.justyou.justme.dto.SendMailDto;
-import com.justyou.justme.model.entity.Member;
+import com.justyou.justme.model.entity.MySQL.Member;
+import com.justyou.justme.model.entity.Redis.RedisUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
@@ -19,28 +20,22 @@ public class MailComponent {
 
     private final JavaMailSender javaMailSender;
 
-    public boolean signUpSender(Member member) {
-        long startTime = System.currentTimeMillis();
-
+    public void signUpSender(RedisUser redisUser, String key) {
         SendMailDto sendMailDto = SendMailDto.builder()
-                .to(member.getEmail())
+                .to(redisUser.getEmail())
                 .from("JUST ME")
                 .subject(" JUST ME - 이메일 인증")
                 .text("<H1>JUST ME 회원 가입을 축하드립니다.</H1>" +
                         "</br>" +
-                        "아래 링크를 클릭하셔서 이메일 인증을 완료 해주세요." +
+                        "아래 링크를 클릭하여 이메일 인증을 완료 해주세요." +
                         "</br>" +
                         "<div><a target='_blank' href='https://localhost:8080/users/email-auth?id=" +
-                        member.getEmailAuthKey() + "'> 이메일 인증하기 </a></div>" +
+                        key + "'> 이메일 인증하기 </a></div>" +
                         "</br>")
                 .build();
-        log.info("이메일 인증 메일 발송완료 TO: " + member.getEmail());
+        log.info("이메일 인증 메일 발송완료 TO: " + redisUser.getEmail());
 
-        boolean result = sendEmail(sendMailDto);
-        long stopTime = System.currentTimeMillis();
-        log.info("이메일 인증메일 발송 결과 : " + result + " | 메일 발송 걸린시간 : " + (stopTime - startTime));
-
-        return result;
+        sendEmail(sendMailDto);
     }
 
     public boolean changePasswordAuthSender(Member member) {
@@ -50,7 +45,7 @@ public class MailComponent {
                 .to(member.getEmail())
                 .from("JUST ME")
                 .subject(" JUST ME - 비밀번호 재설정")
-                .text("아래 링크를 클릭하셔서 비밀번호를 변경 해주세요."
+                .text("아래 링크를 클릭하여 비밀번호를 변경 해주세요."
                         + "</br>" +
                         "<div><a target='_blank' href='https://localhost:8080/password/new?uuid="
                         + member.getPasswordChangeKey() + "'> 비밀번호 재설정 링크 </a></div>"

--- a/src/main/java/com/justyou/justme/component/RedisComponent.java
+++ b/src/main/java/com/justyou/justme/component/RedisComponent.java
@@ -1,0 +1,37 @@
+package com.justyou.justme.component;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class RedisComponent {
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    public void setExpiration(String key, Object obj, Duration expiration) {
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(obj.getClass()));
+        redisTemplate.opsForValue().set(key, obj, expiration);
+    }
+
+    public void set(String key, Object obj) {
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(obj.getClass()));
+    }
+
+
+    public Object get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public boolean delete(String key) {
+
+        return redisTemplate.delete(key);
+    }
+
+    public boolean hasKey(String key) {
+        return redisTemplate.hasKey(key);
+    }
+}

--- a/src/main/java/com/justyou/justme/config/RedisConfig.java
+++ b/src/main/java/com/justyou/justme/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.justyou.justme.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/justyou/justme/controller/MemberController.java
+++ b/src/main/java/com/justyou/justme/controller/MemberController.java
@@ -2,7 +2,7 @@ package com.justyou.justme.controller;
 
 
 import com.justyou.justme.dto.*;
-import com.justyou.justme.model.entity.Member;
+import com.justyou.justme.model.entity.MySQL.Member;
 import com.justyou.justme.security.TokenProvider;
 import com.justyou.justme.service.MemberService;
 import io.swagger.annotations.ApiOperation;
@@ -25,8 +25,14 @@ public class MemberController {
     /*@Valid*/
     @ApiOperation(value = "회원가입")
     @PostMapping("/signUp")
-    public ResponseEntity<ResponseUserDto> signUp(@Valid @RequestBody RequestMemberSignUpDto form) {
+    public ResponseEntity<ResponseUserDto> signUpRedis(@Valid @RequestBody RequestMemberSignUpDto form) {
         return ResponseEntity.ok(this.memberService.signUp(form));
+    }
+
+    @ApiOperation(value = "이메일 인증")
+    @GetMapping("email-auth")
+    public ResponseEntity<ResponseUserDto> emailAuthRedis(@RequestParam String id) {
+        return ResponseEntity.ok(this.memberService.emailAuth(id));
     }
 
     @ApiOperation(value = "휴대폰 중복 체크")
@@ -39,12 +45,6 @@ public class MemberController {
     @GetMapping("/check/email")
     public ResponseEntity<Boolean> checkEmail(@RequestParam String email) {
         return ResponseEntity.ok(this.memberService.checkEmail(email));
-    }
-
-    @ApiOperation(value = "이메일 인증")
-    @GetMapping("email-auth")
-    public ResponseEntity<ResponseUserDto> emailAuth(@RequestParam String id) {
-        return ResponseEntity.ok(this.memberService.emailAuth(id));
     }
 
     @ApiOperation(value = "로그인")

--- a/src/main/java/com/justyou/justme/dto/RequestMemberSignUpDto.java
+++ b/src/main/java/com/justyou/justme/dto/RequestMemberSignUpDto.java
@@ -29,7 +29,6 @@ public class RequestMemberSignUpDto {
     @NotBlank(message = "휴대폰 번호는 필수 입력 값 입니다.")
     private String phone; //휴대폰번호
     @NotNull(message = "생년월일은 필수 입력 값 입니다.")
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
     @Past(message = "생년월일은 오늘 날짜가 불가능합니다.")
     private LocalDate birth;
 

--- a/src/main/java/com/justyou/justme/dto/WithdrawalMemberDto.java
+++ b/src/main/java/com/justyou/justme/dto/WithdrawalMemberDto.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.dto;
 
-import com.justyou.justme.model.entity.Member;
+import com.justyou.justme.model.entity.MySQL.Member;
 import lombok.*;
 
 

--- a/src/main/java/com/justyou/justme/dto/resume/AwardDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/AwardDto.java
@@ -1,7 +1,6 @@
 package com.justyou.justme.dto.resume;
 
-import com.justyou.justme.model.entity.resume.Award;
-import com.justyou.justme.model.entity.resume.Resume;
+import com.justyou.justme.model.entity.MySQL.resume.Award;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/justyou/justme/dto/resume/CertificationDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/CertificationDto.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.dto.resume;
 
-import com.justyou.justme.model.entity.resume.Certification;
+import com.justyou.justme.model.entity.MySQL.resume.Certification;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/justyou/justme/dto/resume/EducationDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/EducationDto.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.dto.resume;
 
-import com.justyou.justme.model.entity.resume.Education;
+import com.justyou.justme.model.entity.MySQL.resume.Education;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/justyou/justme/dto/resume/EtcDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/EtcDto.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.dto.resume;
 
-import com.justyou.justme.model.entity.resume.Etc;
+import com.justyou.justme.model.entity.MySQL.resume.Etc;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/justyou/justme/dto/resume/LanguageDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/LanguageDto.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.dto.resume;
 
-import com.justyou.justme.model.entity.resume.Language;
+import com.justyou.justme.model.entity.MySQL.resume.Language;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/justyou/justme/dto/resume/LinkDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/LinkDto.java
@@ -1,7 +1,7 @@
 package com.justyou.justme.dto.resume;
 
 
-import com.justyou.justme.model.entity.resume.Link;
+import com.justyou.justme.model.entity.MySQL.resume.Link;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/justyou/justme/dto/resume/PortfolioDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/PortfolioDto.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.dto.resume;
 
-import com.justyou.justme.model.entity.resume.Portfolio;
+import com.justyou.justme.model.entity.MySQL.resume.Portfolio;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/justyou/justme/dto/resume/ResumeDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/ResumeDto.java
@@ -1,8 +1,7 @@
 package com.justyou.justme.dto.resume;
 
 
-import com.justyou.justme.model.entity.Member;
-import com.justyou.justme.model.entity.resume.Resume;
+import com.justyou.justme.model.entity.MySQL.resume.Resume;
 import lombok.*;
 
 import java.util.List;

--- a/src/main/java/com/justyou/justme/dto/resume/SkillDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/SkillDto.java
@@ -1,7 +1,6 @@
 package com.justyou.justme.dto.resume;
 
-import com.justyou.justme.model.entity.resume.Skill;
-import jdk.jfr.Name;
+import com.justyou.justme.model.entity.MySQL.resume.Skill;
 import lombok.*;
 
 @Getter

--- a/src/main/java/com/justyou/justme/dto/resume/TrainingCourseDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/TrainingCourseDto.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.dto.resume;
 
-import com.justyou.justme.model.entity.resume.TrainingCourse;
+import com.justyou.justme.model.entity.MySQL.resume.TrainingCourse;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/justyou/justme/dto/resume/WorkExperienceDto.java
+++ b/src/main/java/com/justyou/justme/dto/resume/WorkExperienceDto.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.dto.resume;
 
-import com.justyou.justme.model.entity.resume.WorkExperience;
+import com.justyou.justme.model.entity.MySQL.resume.WorkExperience;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/BaseEntity.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.justyou.justme.model.entity;
+package com.justyou.justme.model.entity.MySQL;
 
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/Member.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/Member.java
@@ -1,9 +1,8 @@
-package com.justyou.justme.model.entity;
+package com.justyou.justme.model.entity.MySQL;
 
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.justyou.justme.dto.RequestMemberSignUpDto;
-import com.justyou.justme.model.entity.resume.Resume;
+import com.justyou.justme.model.entity.MySQL.resume.Resume;
 import lombok.*;
 import org.hibernate.envers.AuditOverride;
 
@@ -52,7 +51,6 @@ public class Member extends BaseEntity {
     //이메일 인증 관련 컬럼
     private boolean emailAuth;
     private LocalDateTime emailAuthDate;
-    private String emailAuthKey;
 
     //비밀번호 변경 관련 컬럼
     private String passwordChangeKey;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/WithdrawalMember.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/WithdrawalMember.java
@@ -1,4 +1,4 @@
-package com.justyou.justme.model.entity;
+package com.justyou.justme.model.entity.MySQL;
 
 
 import com.justyou.justme.dto.WithdrawalMemberDto;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Award.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Award.java
@@ -1,10 +1,7 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.justyou.justme.dto.resume.AwardDto;
-import com.justyou.justme.model.entity.BaseEntity;
 import lombok.*;
-import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
 import java.time.LocalDate;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Certification.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Certification.java
@@ -1,10 +1,7 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.justyou.justme.dto.resume.CertificationDto;
-import com.justyou.justme.model.entity.BaseEntity;
 import lombok.*;
-import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
 import java.time.LocalDate;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Education.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Education.java
@@ -1,10 +1,7 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.justyou.justme.dto.resume.EducationDto;
-import com.justyou.justme.model.entity.BaseEntity;
 import lombok.*;
-import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
 import java.time.LocalDate;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Etc.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Etc.java
@@ -1,8 +1,6 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.justyou.justme.dto.resume.EtcDto;
-import com.justyou.justme.model.entity.BaseEntity;
 import lombok.*;
 
 import javax.persistence.*;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Language.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Language.java
@@ -1,10 +1,7 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.justyou.justme.dto.resume.LanguageDto;
-import com.justyou.justme.model.entity.BaseEntity;
 import lombok.*;
-import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
 import java.time.LocalDate;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Link.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Link.java
@@ -1,10 +1,7 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.justyou.justme.dto.resume.LinkDto;
-import com.justyou.justme.model.entity.BaseEntity;
 import lombok.*;
-import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Portfolio.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Portfolio.java
@@ -1,10 +1,7 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.justyou.justme.dto.resume.PortfolioDto;
-import com.justyou.justme.model.entity.BaseEntity;
 import lombok.*;
-import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
 import java.time.LocalDate;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Resume.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Resume.java
@@ -1,9 +1,9 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
 
 import com.justyou.justme.dto.resume.ResumeDto;
-import com.justyou.justme.model.entity.BaseEntity;
-import com.justyou.justme.model.entity.Member;
+import com.justyou.justme.model.entity.MySQL.BaseEntity;
+import com.justyou.justme.model.entity.MySQL.Member;
 import lombok.*;
 import org.hibernate.envers.AuditOverride;
 

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Skill.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/Skill.java
@@ -1,10 +1,7 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.justyou.justme.dto.resume.SkillDto;
-import com.justyou.justme.model.entity.BaseEntity;
 import lombok.*;
-import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
 

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/TrainingCourse.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/TrainingCourse.java
@@ -1,10 +1,7 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.justyou.justme.dto.resume.TrainingCourseDto;
-import com.justyou.justme.model.entity.BaseEntity;
 import lombok.*;
-import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
 import java.time.LocalDate;

--- a/src/main/java/com/justyou/justme/model/entity/MySQL/resume/WorkExperience.java
+++ b/src/main/java/com/justyou/justme/model/entity/MySQL/resume/WorkExperience.java
@@ -1,10 +1,7 @@
-package com.justyou.justme.model.entity.resume;
+package com.justyou.justme.model.entity.MySQL.resume;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.justyou.justme.dto.resume.WorkExperienceDto;
-import com.justyou.justme.model.entity.BaseEntity;
 import lombok.*;
-import org.hibernate.envers.AuditOverride;
 
 import javax.persistence.*;
 import java.time.LocalDate;

--- a/src/main/java/com/justyou/justme/model/entity/Redis/RedisUser.java
+++ b/src/main/java/com/justyou/justme/model/entity/Redis/RedisUser.java
@@ -1,0 +1,49 @@
+package com.justyou.justme.model.entity.Redis;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.justyou.justme.dto.RequestMemberSignUpDto;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Locale;
+
+
+@Data
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RedisHash("user")
+public class RedisUser implements Serializable {
+    @Id
+    private String id;
+    private String email;
+    private String name;
+    private String password;
+    private String phone;
+    private String address;
+    private String zipCode;
+
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    private LocalDate birth;
+
+    public static RedisUser from(RequestMemberSignUpDto dto) {
+        return RedisUser.builder()
+                .email(dto.getEmail().toLowerCase(Locale.ROOT))
+                .password(dto.getPassword())
+                .name(dto.getName())
+                .birth(dto.getBirth())
+                .phone(dto.getPhone())
+                .address(dto.getAddress())
+                .zipCode(dto.getZipCode())
+                .build();
+    }
+}

--- a/src/main/java/com/justyou/justme/model/repository/MemberRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/MemberRepository.java
@@ -1,7 +1,7 @@
 package com.justyou.justme.model.repository;
 
 
-import com.justyou.justme.model.entity.Member;
+import com.justyou.justme.model.entity.MySQL.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -18,6 +18,4 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndName(String email, String name);
 
     Optional<Member> findByPasswordChangeKey(String uuid);
-
-    Optional<Member> findByEmailAuthKey(String uuid);
 }

--- a/src/main/java/com/justyou/justme/model/repository/RedisUserRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/RedisUserRepository.java
@@ -1,0 +1,10 @@
+package com.justyou.justme.model.repository;
+
+
+import com.justyou.justme.model.entity.Redis.RedisUser;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RedisUserRepository extends CrudRepository<RedisUser, Long> {
+}

--- a/src/main/java/com/justyou/justme/model/repository/Resume/AwardRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/AwardRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.Award;
+import com.justyou.justme.model.entity.MySQL.resume.Award;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/model/repository/Resume/CertificationRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/CertificationRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.Certification;
+import com.justyou.justme.model.entity.MySQL.resume.Certification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/model/repository/Resume/EducationRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/EducationRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.Education;
+import com.justyou.justme.model.entity.MySQL.resume.Education;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/model/repository/Resume/EtcRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/EtcRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.Etc;
+import com.justyou.justme.model.entity.MySQL.resume.Etc;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/model/repository/Resume/LanguageRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/LanguageRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.Language;
+import com.justyou.justme.model.entity.MySQL.resume.Language;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/model/repository/Resume/LinkRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/LinkRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.Link;
+import com.justyou.justme.model.entity.MySQL.resume.Link;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/model/repository/Resume/PortfolioRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/PortfolioRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.Portfolio;
+import com.justyou.justme.model.entity.MySQL.resume.Portfolio;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/model/repository/Resume/ResumeRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/ResumeRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.Resume;
+import com.justyou.justme.model.entity.MySQL.resume.Resume;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/justyou/justme/model/repository/Resume/SkillRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/SkillRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.Skill;
+import com.justyou.justme.model.entity.MySQL.resume.Skill;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/model/repository/Resume/TrainingCourseRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/TrainingCourseRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.TrainingCourse;
+import com.justyou.justme.model.entity.MySQL.resume.TrainingCourse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/model/repository/Resume/WorkExperienceRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/Resume/WorkExperienceRepository.java
@@ -1,6 +1,6 @@
 package com.justyou.justme.model.repository.Resume;
 
-import com.justyou.justme.model.entity.resume.WorkExperience;
+import com.justyou.justme.model.entity.MySQL.resume.WorkExperience;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/model/repository/WithdrawalMemberRepository.java
+++ b/src/main/java/com/justyou/justme/model/repository/WithdrawalMemberRepository.java
@@ -1,7 +1,7 @@
 package com.justyou.justme.model.repository;
 
 
-import com.justyou.justme.model.entity.WithdrawalMember;
+import com.justyou.justme.model.entity.MySQL.WithdrawalMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/justyou/justme/service/ResumeService.java
+++ b/src/main/java/com/justyou/justme/service/ResumeService.java
@@ -4,8 +4,8 @@ package com.justyou.justme.service;
 import com.justyou.justme.dto.resume.*;
 import com.justyou.justme.exception.CustomException;
 import com.justyou.justme.exception.ErrorCode;
-import com.justyou.justme.model.entity.Member;
-import com.justyou.justme.model.entity.resume.*;
+import com.justyou.justme.model.entity.MySQL.Member;
+import com.justyou.justme.model.entity.MySQL.resume.*;
 import com.justyou.justme.model.repository.MemberRepository;
 import com.justyou.justme.model.repository.Resume.*;
 import lombok.RequiredArgsConstructor;
@@ -59,15 +59,15 @@ public class ResumeService {
     public ResponseResumeDto updateResume(ResumeDto dto, Long resumeId, Long memberId) {
         Optional<Member> optionalMember = memberRepository.findById(memberId);
         if (optionalMember.isEmpty()) {
-            //유저 정보가 있지않다면
+            //유저 정보가 있지 않다면
             throw new CustomException(ErrorCode.NOT_FOUND_USER);
         }
         Optional<Resume> optionalResume = resumeRepository.findById(resumeId);
         if (optionalResume.isEmpty()) {
-            //resumeId와 일치하는 이력서 데이터가 없을시
+            //resumeId와 일치 하는 이력서 데이터가 없을시
             throw new CustomException(ErrorCode.NOT_FOUND_RESUME);
         } else if (!Objects.equals(optionalResume.get().getMember().getId(), optionalMember.get().getId())) {
-            //이력서의 존재하는 memberId와 로그인한 resumeId가 일치하지 않는다면
+            //이력서의 존재 하는 memberId와 로그인 한 resumeId가 일치 하지 않는 다면
             throw new CustomException(ErrorCode.NOT_HAVE_ACCESS_RIGHTS);
         }
         Resume resume = optionalResume.get();
@@ -114,7 +114,7 @@ public class ResumeService {
         //sort = new, modify,
         Page<Resume> resumes = resumeRepository
                 .findByMemberIdOrderByModifiedAtDesc(optionalMember.get().getId(), pageable);
-        //수정일 내림차순으로 가져오기
+        //수정일 내림차순 으로 가져오기
         Page<ResponseResumeListDto> responseResumeList = resumes
                 .map(resume -> modelMapper.map(resume, ResponseResumeListDto.class));
 
@@ -125,7 +125,7 @@ public class ResumeService {
     public ResumeDto viewResume(Long memberId, Long resumeId) {
         Optional<Member> optionalMember = memberRepository.findById(memberId);
         if (optionalMember.isEmpty()) {
-            //유저 정보가 있지않다면
+            //유저 정보가 있지 않다면
             throw new CustomException(ErrorCode.NOT_FOUND_USER);
         }
         Optional<Resume> optionalResume = resumeRepository.findById(resumeId);

--- a/src/test/java/com/justyou/justme/service/MemberServiceTest.java
+++ b/src/test/java/com/justyou/justme/service/MemberServiceTest.java
@@ -7,7 +7,7 @@ import com.justyou.justme.dto.ResponseUserDto;
 import com.justyou.justme.dto.UserDto;
 import com.justyou.justme.exception.CustomException;
 import com.justyou.justme.exception.ErrorCode;
-import com.justyou.justme.model.entity.Member;
+import com.justyou.justme.model.entity.MySQL.Member;
 import com.justyou.justme.model.repository.MemberRepository;
 import com.justyou.justme.model.repository.WithdrawalMemberRepository;
 import org.assertj.core.api.Assertions;

--- a/src/test/java/com/justyou/justme/service/ResumeServiceTest.java
+++ b/src/test/java/com/justyou/justme/service/ResumeServiceTest.java
@@ -4,7 +4,7 @@ import com.justyou.justme.dto.resume.ResponseResumeDto;
 import com.justyou.justme.dto.resume.*;
 import com.justyou.justme.exception.CustomException;
 import com.justyou.justme.exception.ErrorCode;
-import com.justyou.justme.model.entity.Member;
+import com.justyou.justme.model.entity.MySQL.Member;
 import com.justyou.justme.model.repository.MemberRepository;
 import com.justyou.justme.model.repository.Resume.ResumeRepository;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
* Redis Configuration, Template 추가
1. 이메일 인증 전 Redis 에 데이터 생성
2. 이메일 인증 후 Redis -> MySQL 로 이관 하도록 구현 -DELETE : MEMBER에서 EMAILAUTHKEY 컬럼 삭제